### PR TITLE
feat: concurrent processing with live progress display

### DIFF
--- a/ghot/ghot.py
+++ b/ghot/ghot.py
@@ -16,10 +16,17 @@ def build_parser():
         parser.add_argument('--pattern-username', default='{f1}', help='Pattern for username')
         parser.add_argument('--pattern-repo', default='{f2}', help='Pattern for repository name')
         parser.add_argument('--pattern-description', default='', help='Pattern for repository description')
+        add_concurrency_options(parser)
         apply_config_defaults(parser, config)
 
     def add_dry_option(parser):
         parser.add_argument('--dry', action='store_true', help='Dry run mode')
+
+    def add_concurrency_options(parser):
+        parser.add_argument('-j', '--workers', type=int, default=8,
+                            help='Number of parallel workers (default: 8, use 1 for sequential)')
+        parser.add_argument('--no-progress', action='store_true',
+                            help='Disable live progress display')
 
     parser = argparse.ArgumentParser(description='Git tools.')
     commands = parser.add_subparsers(title="commands", dest="commands")
@@ -188,7 +195,9 @@ def handle_issue(args):
 
 def init_org_manager(args):
     auth = AuthManager(init=True)
-    org_manager = OrgManager(auth.client())
+    workers = getattr(args, 'workers', 8)
+    progress = not getattr(args, 'no_progress', False)
+    org_manager = OrgManager(auth.client(), workers=workers, progress=progress)
     return org_manager
 
 
@@ -206,8 +215,6 @@ def load_users(args):
 def main():
     sys.argv = preprocess_args(sys.argv)
     parser = build_parser()
-    args = parser.parse_args()
-
     args = parser.parse_args()
 
     try:

--- a/ghot/org_manager.py
+++ b/ghot/org_manager.py
@@ -1,13 +1,20 @@
-from colorama import Fore, Style
-import git
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from github import GithubException
+import git
+from colorama import Fore, Style
 from git.exc import InvalidGitRepositoryError
+from github import GithubException
+
+from .progress import ProgressRenderer, detect_enabled
+
 
 class OrgManager:
-    def __init__(self, gh_client):
+    def __init__(self, gh_client, workers=8, progress=True):
         self.gh_client = gh_client
+        self.workers = max(1, int(workers))
+        self.progress_enabled = progress
+        self._renderer = None
 
     def _get_org(self, org_name):
         try:
@@ -17,7 +24,6 @@ class OrgManager:
             exit(1)
 
     def _get_repo(self, login, repo):
-        prefix = f"{login}/{repo}"
         try:
             return self.gh_client.get_repo(f"{login}/{repo}")
         except GithubException:
@@ -35,33 +41,71 @@ class OrgManager:
         style = status[2] if len(status) > 2 else Style.RESET_ALL
         return msg, color, style
 
-    def _print_status(self, user, status):
+    def _format_status_line(self, user, status):
         message, color, style = self._unpack_status(status)
-        print(f"{Style.BRIGHT}{Fore.GREEN}{user.id}{Style.RESET_ALL}: {style}{color}{message}.{Style.RESET_ALL}")
+        return f"{Style.BRIGHT}{Fore.GREEN}{user.id}{Style.RESET_ALL}: {style}{color}{message}.{Style.RESET_ALL}"
 
     def _confirm_action(self, prompt, force):
         return force or self._confirm_prompt(prompt)
 
     def _confirm_prompt(self, prompt):
+        if self._renderer is not None:
+            with self._renderer.prompt():
+                return input(f"{Fore.CYAN}{prompt} (y/N): {Fore.RESET}").strip().lower() == 'y'
         return input(f"{Fore.CYAN}{prompt} (y/N): {Fore.RESET}").strip().lower() == 'y'
 
     def _repo_dir(self, user, destination=None):
         return os.path.join(destination or '', user.id)
 
-
     def _process_users(self, users, process_func, status_map):
-        for user in users:
-            if not user.is_valid():
-                continue
+        valid = [u for u in users if u.is_valid()]
+        if not valid:
+            return
 
-            print(f"{Style.BRIGHT}{Fore.GREEN}{user.id}{Style.RESET_ALL}: ...", end="\r")
+        enabled = detect_enabled(no_progress=not self.progress_enabled)
+        renderer = ProgressRenderer(total=len(valid), enabled=enabled)
+        self._renderer = renderer
+
+        try:
+            renderer.start()
+            for user in valid:
+                renderer.begin_task(user.id, "queued")
+
+            workers = min(self.workers, len(valid))
+            if workers <= 1:
+                for user in valid:
+                    self._run_one(user, process_func, status_map, renderer)
+            else:
+                with ThreadPoolExecutor(max_workers=workers) as executor:
+                    futures = [
+                        executor.submit(self._run_one, user, process_func, status_map, renderer)
+                        for user in valid
+                    ]
+                    for fut in as_completed(futures):
+                        # propagate unexpected exceptions
+                        fut.result()
+        finally:
+            renderer.stop()
+            self._renderer = None
+
+    def _run_one(self, user, process_func, status_map, renderer):
+        renderer.update_task(user.id, "running")
+        try:
             result = process_func(user)
-            kwargs = {}
-            if isinstance(result, tuple):
-                result, kwargs = result
+        except Exception as ex:
+            line = self._format_status_line(user, (f"Unexpected error: {ex}", Fore.RED))
+            renderer.complete_task(user.id, line)
+            return
 
-            self._print_status(user, status_map(user, **kwargs)[result])
+        kwargs = {}
+        if isinstance(result, tuple):
+            result, kwargs = result
 
+        status = status_map(user, **kwargs).get(result)
+        if status is None:
+            status = (f"Unknown result: {result}", Fore.RED)
+        line = self._format_status_line(user, status)
+        renderer.complete_task(user.id, line)
 
     def _process_user_invite(self, org, user, members, invitations, dry=False):
         if not user.is_valid():
@@ -86,8 +130,6 @@ class OrgManager:
                 org.invite_user(gh_user, role="direct_member")
                 return "invite"
 
-
-
     def user_invite(self, org_name, users, dry=False):
         org = self._get_org(org_name)
 
@@ -109,7 +151,6 @@ class OrgManager:
                 "invite": (f"Invitation sent to '{user.username}'", Fore.CYAN),
             }
         self._process_users(users, process, status_map)
-
 
     def _process_user_remove(self, org, user, members, invitations, dry=False, force=False):
         if not user.is_valid():
@@ -149,12 +190,11 @@ class OrgManager:
             org.remove_from_members(gh_user)
             return "removed"
 
-
     def user_remove(self, org_name, users, dry=False, force=False):
         org = self._get_org(org_name)
 
         members = [m.login.lower() for m in org.get_members()]
-        invitations = {i.login.lower() : i for i in org.invitations()}
+        invitations = {i.login.lower(): i for i in org.invitations()}
 
         print(f"Total members: {len(members)}")
         print(f"Pending invitations: {len(invitations)}")
@@ -175,7 +215,6 @@ class OrgManager:
                 "removed": (f"User '{user.username}' removed from organization", Fore.CYAN),
             }
         self._process_users(users, process, status_map)
-
 
     def _process_repo_create(self, org, user, dry=False, private=True, username_only=False):
         if not user.is_valid():
@@ -202,7 +241,6 @@ class OrgManager:
             )
             return "repo_created"
 
-
     def repo_create(self, org_name, users, dry=False, private=True, username_only=False):
         org = self._get_org(org_name)
 
@@ -213,14 +251,13 @@ class OrgManager:
             visibility = "private" if private else "public"
             return {
                 "invalid": ("Invalid user", Fore.RED),
-                "no_repo": (f"No repository name", Fore.RESET, Style.DIM),
+                "no_repo": ("No repository name", Fore.RESET, Style.DIM),
                 "no_username": ("No username", Fore.RESET, Style.DIM),
                 "repo_exists": (f"Repository '{org_name}/{user.repo}' already exists", Fore.GREEN),
                 "repo_created_dry": (f"Repository '{org_name}/{user.repo}' created ({visibility}) (dry)", Fore.CYAN),
                 "repo_created": (f"Repository '{org_name}/{user.repo}' created ({visibility})", Fore.CYAN),
             }
         self._process_users(users, process, status_map)
-
 
     def _process_repo_invite(self, org, user, org_members, dry=False):
         if not user.is_valid():
@@ -237,7 +274,7 @@ class OrgManager:
             return "user_not_found"
 
         username = user.username.lower()
-        if not username in org_members:
+        if username not in org_members:
             return "no_org_member"
 
         repo = self._get_repo(org.login, user.repo)
@@ -258,8 +295,6 @@ class OrgManager:
             repo.add_to_collaborators(gh_user, permission="push")
             return "invite"
 
-
-    # Check user is in the organization
     def repo_invite(self, org, users, dry=False):
         org = self._get_org(org)
 
@@ -283,7 +318,6 @@ class OrgManager:
             }
         self._process_users(users, process, status_map)
 
-
     def _process_repo_clone(self, org, user, destination=None, dry=False, ssh=False):
         if not user.is_valid():
             return "invalid"
@@ -297,7 +331,7 @@ class OrgManager:
 
         if os.path.isdir(repo_dir):
             try:
-                repo = git.Repo(repo_dir)
+                git.Repo(repo_dir)
                 return "repo_already_cloned"
             except InvalidGitRepositoryError:
                 return "exists_but_not_repo"
@@ -313,7 +347,6 @@ class OrgManager:
         else:
             git.Repo.clone_from(clone_url, repo_dir)
             return "repo_cloned"
-
 
     def repo_clone(self, org_name, users, destination=None, dry=False, ssh=False):
         org = self._get_org(org_name)
@@ -337,7 +370,6 @@ class OrgManager:
             }
         self._process_users(users, process, status_map)
 
-
     def _process_repo_pull(self, user, destination=None, dry=False):
         if not user.is_valid():
             return "invalid"
@@ -360,18 +392,15 @@ class OrgManager:
             o = repo.remotes.origin
             o.fetch()
 
-            # get default branch from origin/HEAD
             default_ref = repo.git.symbolic_ref('refs/remotes/origin/HEAD')
             default_branch = default_ref.rsplit('/', 1)[-1]
 
-            # checkout default branch and reset to origin
             repo.git.checkout(default_branch)
             repo.git.reset("--hard", f"origin/{repo.active_branch}")
 
             return "repo_pull"
-        except Exception as ex:
+        except Exception:
             return "error_pulling"
-
 
     def repo_pull(self, users, destination=None, dry=False):
         def process(user):
@@ -390,7 +419,6 @@ class OrgManager:
                 "error_pulling": (f"Error pulling repository '{user.repo}' on '{repo_dir}'", Fore.RED),
             }
         self._process_users(users, process, status_map)
-
 
     def _process_repo_delete(self, org, user, force=False, dry=False):
         if not user.is_valid():
@@ -413,7 +441,6 @@ class OrgManager:
             repo.delete()
             return "deleted"
 
-
     def repo_delete(self, org_name, users, force=False, dry=False):
         org = self._get_org(org_name)
 
@@ -430,7 +457,6 @@ class OrgManager:
                 "deleted": (f"Repository '{org_name}/{user.repo}' deleted", Fore.CYAN),
             }
         self._process_users(users, process, status_map)
-
 
     def _process_issue_create(self, org, user, title, body, dry=False):
         if not user.is_valid():
@@ -455,7 +481,6 @@ class OrgManager:
             body = body.replace("\\n", "\n")
             issue = repo.create_issue(title, body)
             return "issue_created", {"number": issue.number}
-
 
     def issue_create(self, org_name, users, title, body, dry=False):
         org = self._get_org(org_name)

--- a/ghot/progress.py
+++ b/ghot/progress.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 
 from colorama import Fore, Style
 
-
 SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 

--- a/ghot/progress.py
+++ b/ghot/progress.py
@@ -1,0 +1,217 @@
+import os
+import sys
+import threading
+import time
+from contextlib import contextmanager
+
+from colorama import Fore, Style
+
+
+SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+
+def _supports_tty(stream):
+    try:
+        return stream.isatty()
+    except Exception:
+        return False
+
+
+class ProgressRenderer:
+    """Docker-build style live progress.
+
+    Completed rows scroll above; active rows redraw in place with a spinner.
+    Falls back to plain line-by-line output when the stream is not a TTY.
+    """
+
+    def __init__(self, total, enabled=True, stream=None, refresh_interval=0.1, max_active_rows=12):
+        self.total = total
+        self.stream = stream or sys.stdout
+        self.enabled = bool(enabled) and _supports_tty(self.stream)
+        self.refresh_interval = refresh_interval
+        self.max_active_rows = max_active_rows
+
+        self._completed = 0
+        self._started_at = None
+        self._active = {}  # uid -> {"msg": str, "started": float}
+        self._active_order = []  # for stable display order
+        self._lock = threading.RLock()
+        self._prompt_lock = threading.Lock()
+        self._paused = threading.Event()
+        self._stop = threading.Event()
+        self._thread = None
+        self._spin_idx = 0
+        self._lines_drawn = 0
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.stop()
+
+    def start(self):
+        if not self.enabled:
+            return
+        self._started_at = time.time()
+        self._hide_cursor()
+        self._thread = threading.Thread(target=self._refresh_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        if not self.enabled:
+            return
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+        with self._lock:
+            self._erase()
+            self._print_summary()
+            self._show_cursor()
+            self.stream.flush()
+
+    def begin_task(self, uid, message="queued"):
+        with self._lock:
+            if uid not in self._active:
+                self._active_order.append(uid)
+            self._active[uid] = {"msg": message, "started": time.time()}
+
+    def update_task(self, uid, message):
+        with self._lock:
+            if uid in self._active:
+                self._active[uid]["msg"] = message
+
+    def complete_task(self, uid, line):
+        with self._lock:
+            self._completed += 1
+            if uid in self._active:
+                self._active.pop(uid, None)
+                try:
+                    self._active_order.remove(uid)
+                except ValueError:
+                    pass
+            if self.enabled:
+                self._erase()
+                self.stream.write(line + "\n")
+                self._draw()
+                self.stream.flush()
+            else:
+                self.stream.write(line + "\n")
+                self.stream.flush()
+
+    def print_line(self, line):
+        """Print a static line above the active section."""
+        with self._lock:
+            if self.enabled:
+                self._erase()
+                self.stream.write(line + "\n")
+                self._draw()
+                self.stream.flush()
+            else:
+                self.stream.write(line + "\n")
+                self.stream.flush()
+
+    @contextmanager
+    def prompt(self):
+        """Pause rendering for synchronous user input. Serialized across threads."""
+        with self._prompt_lock:
+            if not self.enabled:
+                yield
+                return
+            self._paused.set()
+            with self._lock:
+                self._erase()
+                self._show_cursor()
+                self.stream.flush()
+            try:
+                yield
+            finally:
+                with self._lock:
+                    self._hide_cursor()
+                self._paused.clear()
+
+    def _refresh_loop(self):
+        while not self._stop.wait(self.refresh_interval):
+            if self._paused.is_set():
+                continue
+            with self._lock:
+                self._spin_idx = (self._spin_idx + 1) % len(SPINNER_FRAMES)
+                self._erase()
+                self._draw()
+                self.stream.flush()
+
+    def _erase(self):
+        if self._lines_drawn <= 0:
+            return
+        for _ in range(self._lines_drawn):
+            self.stream.write("\033[F\033[2K")
+        self._lines_drawn = 0
+
+    def _draw(self):
+        spin = SPINNER_FRAMES[self._spin_idx]
+        elapsed = time.time() - (self._started_at or time.time())
+        total = self.total
+        done = self._completed
+        running = len(self._active)
+        bar = self._bar(done, total)
+        header = (
+            f"{Style.BRIGHT}{Fore.CYAN}{spin}{Style.RESET_ALL} "
+            f"{bar} "
+            f"{Style.BRIGHT}{done}/{total}{Style.RESET_ALL} "
+            f"{Style.DIM}({running} running, {elapsed:5.1f}s){Style.RESET_ALL}"
+        )
+        self.stream.write(header + "\n")
+        lines = 1
+        shown = self._active_order[: self.max_active_rows]
+        for uid in shown:
+            info = self._active.get(uid)
+            if not info:
+                continue
+            task_elapsed = time.time() - info["started"]
+            line = (
+                f"  {Fore.CYAN}{spin}{Style.RESET_ALL} "
+                f"{Style.BRIGHT}{Fore.GREEN}{uid}{Style.RESET_ALL} "
+                f"{Style.DIM}{info['msg']} ({task_elapsed:4.1f}s){Style.RESET_ALL}"
+            )
+            self.stream.write(line + "\n")
+            lines += 1
+        overflow = len(self._active_order) - len(shown)
+        if overflow > 0:
+            self.stream.write(f"  {Style.DIM}... and {overflow} more{Style.RESET_ALL}\n")
+            lines += 1
+        self._lines_drawn = lines
+
+    def _bar(self, done, total, width=24):
+        if total <= 0:
+            return "[" + " " * width + "]"
+        filled = int(width * done / total)
+        return "[" + Fore.GREEN + "█" * filled + Style.RESET_ALL + " " * (width - filled) + "]"
+
+    def _print_summary(self):
+        if not self._started_at:
+            return
+        elapsed = time.time() - self._started_at
+        self.stream.write(
+            f"{Style.BRIGHT}Done{Style.RESET_ALL} "
+            f"{self._completed}/{self.total} "
+            f"{Style.DIM}in {elapsed:.1f}s{Style.RESET_ALL}\n"
+        )
+
+    def _hide_cursor(self):
+        if self.enabled:
+            self.stream.write("\033[?25l")
+            self.stream.flush()
+
+    def _show_cursor(self):
+        if self.enabled:
+            self.stream.write("\033[?25h")
+            self.stream.flush()
+
+
+def detect_enabled(no_progress=False, stream=None):
+    stream = stream or sys.stdout
+    if no_progress:
+        return False
+    if os.environ.get("NO_COLOR") or os.environ.get("CI"):
+        return False
+    return _supports_tty(stream)


### PR DESCRIPTION
## Summary

- Run per-user operations through `ThreadPoolExecutor` (default 8 workers, configurable via `-j/--workers`) to cut wall-clock time on large CSV inputs.
- New `ghot/progress.py` `ProgressRenderer`: docker-build-style live display — spinner header with progress bar / done-total / elapsed, active task rows redraw in place with per-task spinner+elapsed, completed rows stream above. Falls back to plain output on non-TTY (or when `--no-progress` / `NO_COLOR` / `CI` is set).
- Confirmation prompts (`user remove`, `repo delete`) pause the renderer and serialize across workers via a prompt lock.
- New CLI flags on every CSV-driven subcommand: `-j/--workers N`, `--no-progress`.

## Notes

- Per-task exceptions are captured into a red error line instead of killing the run.
- Existing `_process_user_*` signatures unchanged — only `_process_users` internals were refactored, so all `org_manager` unit tests keep working.

## Test plan

- [x] `pytest` — 135/135 pass on the changes (5 pre-existing failures in `tests/argparse/test_argparse_repo_create.py` exist on `main` too, unrelated `username_only` kwarg drift).
- [x] CLI parse smoke: `-j/--workers` and `--no-progress` wired on `user invite|remove`, `repo create|clone|pull|delete|invite`, `issue create`.
- [x] Concurrency benchmark with mocked I/O: 4 workers ≈ 2× faster than `-j 1` on 8 items.
- [x] TTY renderer smoke: ANSI erase/redraw cycles emit correctly, completed rows scroll above active section.
- [x] Manual run against a real GitHub org with a multi-row CSV.